### PR TITLE
Add Docker support with Dockerfile, .dockerignore, and documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Git and local metadata
+.git
+.github
+.gitignore
+
+# Python caches and virtual environments
+__pycache__/
+*.py[cod]
+*.so
+venv/
+.venv/
+
+# Runtime/generated artifacts
+outputs/
+.cache/
+.gradio/
+*.log
+
+# Local model artifacts (download at runtime in container)
+voices/
+*.pth
+
+# Editor/OS files
+.vscode/
+.idea/
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ RUN apt-get update \
 COPY requirements.txt ./
 
 RUN pip install --upgrade pip setuptools wheel \
-    && pip install -r requirements.txt
+    && pip install -r requirements.txt \
+    && python -m spacy download en_core_web_sm \
+    && python -c "import spacy; spacy.load('en_core_web_sm'); print('spaCy model OK')"
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    HF_HOME=/app/.cache/huggingface
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        ffmpeg \
+        espeak-ng \
+        libsndfile1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+
+RUN pip install --upgrade pip setuptools wheel \
+    && pip install -r requirements.txt
+
+COPY . .
+
+RUN useradd --create-home --uid 10001 appuser \
+    && mkdir -p /app/outputs /app/voices /app/.cache \
+    && chown -R appuser:appuser /app
+
+USER appuser
+
+EXPOSE 7860
+
+CMD ["python", "gradio_interface.py", "--host", "0.0.0.0", "--port", "7860"]

--- a/README.md
+++ b/README.md
@@ -100,6 +100,38 @@ print(torch.cuda.is_available())  # Should print True if CUDA is available
 
 The system will automatically download required models and voice files on first run.
 
+## Docker Quick Start
+
+This project can be run in a CPU-first Docker setup with runtime model and voice downloads.
+
+### Build and Run with Docker
+
+```bash
+docker build -t kokoro-tts-local:cpu .
+docker run --rm -it \
+   -p 7860:7860 \
+   -v "$(pwd)/outputs:/app/outputs" \
+   -v "$(pwd)/voices:/app/voices" \
+   -v "$(pwd)/.cache:/app/.cache" \
+   kokoro-tts-local:cpu
+```
+
+Open `http://localhost:7860` in your browser.
+
+### Run with Docker Compose
+
+```bash
+docker compose up --build
+```
+
+### Docker Notes
+
+- First startup can take longer because model and voice files are downloaded from Hugging Face.
+- Volumes for `outputs`, `voices`, and `.cache` are recommended so downloads and generated audio persist across restarts.
+- The Docker image pre-installs `en_core_web_sm` during build to avoid non-root runtime initialization errors.
+- This initial Docker support is CPU-first. GPU and pre-baked model image variants are intentionally out of scope for this first implementation.
+- To force offline mode after assets are downloaded, set `HF_HUB_OFFLINE=1` in your Docker environment.
+
 ## Offline Mode
 
 After the initial setup, you can run Kokoro-TTS-Local completely offline without an internet connection.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  kokoro-tts:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: kokoro-tts-local
+    ports:
+      - "7860:7860"
+    environment:
+      - HF_HUB_OFFLINE=0
+    volumes:
+      - ./outputs:/app/outputs
+      - ./voices:/app/voices
+      - ./.cache:/app/.cache
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
This PR adds Docker support to run Kokoro-TTS-Local in a reproducible containerized setup and documents the workflow in the README.

## What’s Included
- Added .dockerignore to reduce build context and speed up image builds.
- Added Dockerfile for application containerization.
- Added docker-compose.yml for service orchestration and easier local startup.
- Updated README.md with Docker setup and usage instructions.

## Why
Running the project with Docker simplifies onboarding and avoids local environment differences by packaging dependencies and runtime configuration into a consistent container environment.

## Files Changed
- .dockerignore (new)
- Dockerfile (new)
- docker-compose.yml (new)
- README.md (updated with Docker docs)

## How to Test
1. Build and start with Docker Compose:
   - `docker compose up --build`
2. Confirm the app starts successfully and dependencies load in the container.
3. Follow the new README Docker section to run expected TTS flows.

## Notes
- This PR is focused on containerization and documentation only; no application logic changes are included.