### PR TITLE
Add Docker support with Dockerfile, .dockerignore, and documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Git and local metadata
+.git
+.github
+.gitignore
+
+# Python caches and virtual environments
+__pycache__/
+*.py[cod]
+*.so
+venv/
+.venv/
+
+# Runtime/generated artifacts
+outputs/
+.cache/
+.gradio/
+*.log
+
+# Local model artifacts (download at runtime in container)
+voices/
+*.pth
+
+# Editor/OS files
+.vscode/
+.idea/
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ RUN apt-get update \
 COPY requirements.txt ./
 
 RUN pip install --upgrade pip setuptools wheel \
-    && pip install -r requirements.txt
+    && pip install -r requirements.txt \
+    && python -m spacy download en_core_web_sm \
+    && python -c "import spacy; spacy.load('en_core_web_sm'); print('spaCy model OK')"
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM python:3.11-slim
+FROM python:3.11-slim@sha256:06fa338add3c2ab8daeff7304a6bb204c68f67743b13553a8999605fc8097c58
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PIP_NO_CACHE_DIR=1 \
     HF_HOME=/app/.cache/huggingface
 
 WORKDIR /app
@@ -11,15 +10,20 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
         cmake \
+        curl \
         ffmpeg \
         espeak-ng \
         libsndfile1 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt ./
+# NOTE: requirements.txt uses unpinned dependencies for flexibility.
+# For fully reproducible builds, generate a lock file:
+#   pip install -r requirements.txt && pip freeze > requirements-lock.txt
+# Then replace "requirements.txt" below with "requirements-lock.txt".
 
-RUN pip install --upgrade pip setuptools wheel \
-    && pip install -r requirements.txt \
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
+    && pip install --no-cache-dir -r requirements.txt \
     && python -m spacy download en_core_web_sm \
     && python -c "import spacy; spacy.load('en_core_web_sm'); print('spaCy model OK')"
 
@@ -32,5 +36,9 @@ RUN useradd --create-home --uid 10001 appuser \
 USER appuser
 
 EXPOSE 7860
+
+# Allow extra time on first start for model/voice downloads from Hugging Face
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+    CMD curl -f http://localhost:7860/ || exit 1
 
 CMD ["python", "gradio_interface.py", "--host", "0.0.0.0", "--port", "7860"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    HF_HOME=/app/.cache/huggingface
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        ffmpeg \
+        espeak-ng \
+        libsndfile1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+
+RUN pip install --upgrade pip setuptools wheel \
+    && pip install -r requirements.txt
+
+COPY . .
+
+RUN useradd --create-home --uid 10001 appuser \
+    && mkdir -p /app/outputs /app/voices /app/.cache \
+    && chown -R appuser:appuser /app
+
+USER appuser
+
+EXPOSE 7860
+
+CMD ["python", "gradio_interface.py", "--host", "0.0.0.0", "--port", "7860"]

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ This project can be run in a CPU-first Docker setup with runtime model and voice
 
 ### Build and Run with Docker
 
+**Linux/macOS (bash/zsh):**
 ```bash
 docker build -t kokoro-tts-local:cpu .
 docker run --rm -it \
@@ -113,6 +114,17 @@ docker run --rm -it \
    -v "$(pwd)/outputs:/app/outputs" \
    -v "$(pwd)/voices:/app/voices" \
    -v "$(pwd)/.cache:/app/.cache" \
+   kokoro-tts-local:cpu
+```
+
+**Windows (PowerShell):**
+```powershell
+docker build -t kokoro-tts-local:cpu .
+docker run --rm -it `
+   -p 7860:7860 `
+   -v "${PWD}/outputs:/app/outputs" `
+   -v "${PWD}/voices:/app/voices" `
+   -v "${PWD}/.cache:/app/.cache" `
    kokoro-tts-local:cpu
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,38 @@ print(torch.cuda.is_available())  # Should print True if CUDA is available
 
 The system will automatically download required models and voice files on first run.
 
+## Docker Quick Start
+
+This project can be run in a CPU-first Docker setup with runtime model and voice downloads.
+
+### Build and Run with Docker
+
+```bash
+docker build -t kokoro-tts-local:cpu .
+docker run --rm -it \
+   -p 7860:7860 \
+   -v "$(pwd)/outputs:/app/outputs" \
+   -v "$(pwd)/voices:/app/voices" \
+   -v "$(pwd)/.cache:/app/.cache" \
+   kokoro-tts-local:cpu
+```
+
+Open `http://localhost:7860` in your browser.
+
+### Run with Docker Compose
+
+```bash
+docker compose up --build
+```
+
+### Docker Notes
+
+- First startup can take longer because model and voice files are downloaded from Hugging Face.
+- Volumes for `outputs`, `voices`, and `.cache` are recommended so downloads and generated audio persist across restarts.
+- The Docker image pre-installs `en_core_web_sm` during build to avoid non-root runtime initialization errors.
+- This initial Docker support is CPU-first. GPU and pre-baked model image variants are intentionally out of scope for this first implementation.
+- To force offline mode after assets are downloaded, set `HF_HUB_OFFLINE=1` in your Docker environment.
+
 ## Offline Mode
 
 After the initial setup, you can run Kokoro-TTS-Local completely offline without an internet connection.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     ports:
       - "7860:7860"
     environment:
-      - HF_HUB_OFFLINE=0
+      # Uncomment the line below to run fully offline after initial model download
+      # - HF_HUB_OFFLINE=1
     volumes:
       - ./outputs:/app/outputs
       - ./voices:/app/voices

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  kokoro-tts:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: kokoro-tts-local
+    ports:
+      - "7860:7860"
+    environment:
+      - HF_HUB_OFFLINE=0
+    volumes:
+      - ./outputs:/app/outputs
+      - ./voices:/app/voices
+      - ./.cache:/app/.cache
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
This PR adds Docker support to run Kokoro-TTS-Local in a reproducible containerized setup and documents the workflow in the README.

## What's Included
- Added \.dockerignore\ to reduce build context and speed up image builds.
- Added \Dockerfile\ for application containerization.
- Added \docker-compose.yml\ for service orchestration and easier local startup.
- Updated \README.md\ with Docker setup and usage instructions.

## Review Fixes Applied
- Pinned base image to a digest for reproducibility
- Added \curl\ to apt-get and a \HEALTHCHECK\ instruction for restart-policy safety
- Removed \PIP_NO_CACHE_DIR\ from \ENV\ block (use \--no-cache-dir\ pip flag instead)
- Added comment guidance for requirements pinning / lock file
- Removed redundant \HF_HUB_OFFLINE=0\ from \docker-compose.yml\
- Added Windows PowerShell-compatible \docker run\ example to README

## How to Test
1. Build and start with Docker Compose:
   - \docker compose up --build\
2. Confirm the app starts successfully and dependencies load in the container.
3. Follow the README Docker section to run expected TTS flows.

## Notes
- This PR is focused on containerization and documentation only; no application logic changes are included.
- Replaces #26 (from fork) — all review findings have been addressed.