### PR TITLE
Fix Gradio web UI routing non-English voices through English G2P

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,8 +502,9 @@ This will automatically detect and report:
 
 3. **Japanese Voices Produce Wrong/Garbled Speech**
    - **Problem:** Selecting a Japanese voice (e.g. `jf_alpha`) produces nonsense audio, or Japanese G2P fails with a dictionary error
-   - **Cause:** `fugashi`/`unidic` ship without dictionary data; it must be downloaded separately
+   - **Cause 1:** `fugashi`/`unidic` ship without dictionary data; it must be downloaded separately
    - **Solution:** Run `python -m unidic download` (~1 GB, one-time) in your virtual environment
+   - **Cause 2:** Language routing — if you have already run `unidic download` but the web UI still produces garbled audio, the text may be running through the English G2P pipeline. This was a bug in `gradio_interface.py` (fixed) where the voice's language was misdetected; make sure you are on an up-to-date version.
 
 4. **Offline Mode / Network Connection Issues**
    - **Problem:** Getting "Failed to resolve 'huggingface.co'" errors even with cached files

--- a/gradio_interface.py
+++ b/gradio_interface.py
@@ -34,7 +34,7 @@ from typing import Union, List, Optional, Tuple, Dict, Any
 from models import (
     list_available_voices, build_model,
     generate_speech, download_voice_files, EnhancedKPipeline,
-    get_safe_voice_path
+    get_safe_voice_path, get_language_code_from_voice
 )
 import speed_dial
 
@@ -104,8 +104,7 @@ def get_pipeline_for_voice(voice_name: str) -> EnhancedKPipeline:
     """
     Determine the language code from the voice prefix and return the associated pipeline.
     """
-    prefix = voice_name[:2].lower() if len(voice_name) >= 2 else "af"
-    lang_code = LANG_MAP.get(prefix, "a")
+    lang_code = get_language_code_from_voice(voice_name)
     if lang_code not in pipelines:
         print(f"[INFO] Creating pipeline for lang_code='{lang_code}'")
         pipelines[lang_code] = build_model(None, device, lang_code=lang_code)


### PR DESCRIPTION
## Summary

Fixes #31 — in the Gradio web UI, selecting a non-English voice (e.g. `jf_alpha`) produced garbled audio because text was always run through the **English** G2P pipeline.

## Root cause

`get_pipeline_for_voice()` looked up `LANG_MAP` with a **2-char** prefix (`voice_name[:2]` → `"jf"`), but `LANG_MAP`'s keys are **3 chars** with a trailing underscore (`"jf_"`). The lookup never matched, so every voice fell through to the `"a"` (English) default.

## Fix

- Reuse the canonical `get_language_code_from_voice()` helper from `models.py` (the same one the merged #30 CLI fix uses) instead of the duplicated prefix map.
- `LANG_MAP` is kept for the `startswith()` dispatch check, where its 3-char keys are correct.
- Updated README troubleshooting entry #3, which previously attributed this symptom solely to missing UniDic dictionary data.

## Scope

Only `gradio_interface.py` is affected. `tts_demo.py` was fixed in #30; `chinese_tts_demo.py` hardcodes `lang_code='z'` and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)